### PR TITLE
Revert dependabot changes in "Include `*.yaml` files in yamllint."

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,24 +5,27 @@ updates:
       prefix: docker
     directory: /
     package-ecosystem: docker
-    schedule: &interval
+    schedule:
       interval: daily
   - commit-message:
       include: scope
       prefix: github-actions
     directory: /
     package-ecosystem: github-actions
-    schedule: *interval
+    schedule:
+      interval: daily
   - commit-message:
       include: scope
       prefix: gitsubmodule
     directory: /
     package-ecosystem: gitsubmodule
-    schedule: *interval
+    schedule:
+      interval: daily
   - commit-message:
       include: scope
       prefix: pip
     directory: /
     package-ecosystem: pip
-    schedule: *interval
+    schedule:
+      interval: daily
 version: 2


### PR DESCRIPTION
This reverts commit 1d49a56bba42d5adb5dec78f8119a5620fb96514.